### PR TITLE
Offline dust

### DIFF
--- a/GeosCore/dust_mod.F
+++ b/GeosCore/dust_mod.F
@@ -1268,10 +1268,10 @@
                LINTERP=.TRUE.
             ENDIF
 
-            ! There are always 5 + (NRHAER*2) preceding size-res dust
+            ! There are always 5 + (NRHAER*3) preceding size-res dust
             ! Each subsequent set is separated by a further distance of
             ! (NRHAER + NDUST)
-            NOUT = 5 + (NRHAER*2) + ((NRHAER+NDUST)*(W-1)) + N
+            NOUT = 5 + (NRHAER*3) + ((NRHAER+NDUST)*(W-1)) + N
 
             DO L = 1, LD21
             DO J = 1, JJPAR

--- a/GeosCore/hcoi_gc_diagn_mod.F90
+++ b/GeosCore/hcoi_gc_diagn_mod.F90
@@ -668,8 +668,11 @@ CONTAINS
        ! Get Ext. Nr of used extension
        ExtNr = GetExtNr( HcoState%Config%ExtList, 'DustDead' )
        IF ( ExtNr <= 0 ) ExtNr = GetExtNr( HcoState%Config%ExtList, 'DustGinoux' )
-!      try commenting this out as we want to be able to run with dust on
-!      but without the dust extension (emissions are read in offline)
+
+!     Commented out so that when dust extension is turned off 
+!     then the model defaults to offline dust based on HEMCO_Config settings
+!     (these must be uncommented in the HEMCO_Config and the dust_emission_YYYYMMDDHH.nc
+!     offline emissions from HEMCO standalone must be created/downloaded (DAR 2018)  
 !       IF ( ExtNr <= 0 ) THEN
 !          CALL HCO_Error( 'Cannot find dust extension', RC, THISLOC=LOC )
 !          RETURN      

--- a/GeosCore/hcoi_gc_diagn_mod.F90
+++ b/GeosCore/hcoi_gc_diagn_mod.F90
@@ -668,10 +668,12 @@ CONTAINS
        ! Get Ext. Nr of used extension
        ExtNr = GetExtNr( HcoState%Config%ExtList, 'DustDead' )
        IF ( ExtNr <= 0 ) ExtNr = GetExtNr( HcoState%Config%ExtList, 'DustGinoux' )
-       IF ( ExtNr <= 0 ) THEN
-          CALL HCO_Error( 'Cannot find dust extension', RC, THISLOC=LOC )
-          RETURN      
-       ENDIF
+!      try commenting this out as we want to be able to run with dust on
+!      but without the dust extension (emissions are read in offline)
+!       IF ( ExtNr <= 0 ) THEN
+!          CALL HCO_Error( 'Cannot find dust extension', RC, THISLOC=LOC )
+!          RETURN      
+!       ENDIF
 
        ! Do for each dust bin
        DO I = 1, Input_Opt%N_DUST_BINS

--- a/HEMCO/Core/hco_chartools_mod.F90
+++ b/HEMCO/Core/hco_chartools_mod.F90
@@ -17,6 +17,7 @@ MODULE HCO_CharTools_Mod
 ! !USES:
 !
   USE HCO_Error_Mod
+  USE HCO_Types_Mod
 
   IMPLICIT NONE
   PRIVATE
@@ -846,7 +847,7 @@ CONTAINS
 !
 ! !OUTPUT PARAMETERS
 !
-    CHARACTER(LEN=*), INTENT(  OUT) :: LINE        ! Next (valid) line in stream
+    CHARACTER(LEN=OPTLEN), INTENT(  OUT) :: LINE        ! Next (valid) line in stream
 !
 ! !INPUT/OUTPUT PARAMETERS
 !
@@ -862,7 +863,7 @@ CONTAINS
 ! LOCAL VARIABLES:
 !
     INTEGER             :: IOS
-    CHARACTER(LEN=2047) :: DUM
+    CHARACTER(LEN=10000) :: DUM
 
     !=================================================================
     ! GetNextLine begins here
@@ -910,7 +911,7 @@ CONTAINS
 !
 ! !OUTPUT PARAMETERS:
 !
-    CHARACTER(LEN=*), INTENT(INOUT) :: LINE     ! Line
+    CHARACTER(LEN=OPTLEN), INTENT(INOUT) :: LINE     ! Line
     LOGICAL,          INTENT(INOUT) :: EOF      ! End of file?
     INTEGER,          INTENT(INOUT) :: RC       ! Return code 
 ! 
@@ -925,7 +926,7 @@ CONTAINS
 !
     INTEGER             :: IOS
     CHARACTER(LEN=255)  :: MSG
-    CHARACTER(LEN=4095) :: DUM
+    CHARACTER(LEN=OPTLEN) :: DUM
 
     !=================================================================
     ! HCO_ReadLine begins here!
@@ -937,7 +938,7 @@ CONTAINS
 
     ! Read a line from the file
     READ( LUN, '(a)', IOSTAT=IOS ) DUM
-
+    WRITE( 6,*) DUM
     ! IO Status < 0: EOF condition
     IF ( IOS < 0 ) THEN
        EOF = .TRUE.
@@ -957,7 +958,7 @@ CONTAINS
     ! Make sure that character string DUM is not longer than LINE
     IF ( LEN(TRIM(DUM)) > LEN(LINE) ) THEN
        WRITE( 6, '(a)' ) REPEAT( '=', 79 )
-       WRITE( 6, * ) ' Line is too long - cannot read line ', TRIM(DUM)   
+       WRITE( 6, * ) ' Line is too long - cannot read line ', TRIM(DUM),LEN(DUM),LEN(LINE) 
        WRITE( 6, * ) ' '
        WRITE( 6, * ) ' To fix this, increase length of argument `LINE` in '
        WRITE( 6, * ) ' HCO_ReadLine (hco_chartools_mod.F90)' 

--- a/HEMCO/Core/hco_config_mod.F90
+++ b/HEMCO/Core/hco_config_mod.F90
@@ -162,7 +162,7 @@ CONTAINS
     LOGICAL              :: EXISTS, NEST
     CHARACTER(LEN=255)   :: MSG,    LOC
     CHARACTER(LEN=2047)  :: CFDIR 
-    CHARACTER(LEN=2047)  :: LINE
+    CHARACTER(LEN=OPTLEN)  :: LINE
 
     !======================================================================
     ! Config_ReadFile begins here
@@ -550,7 +550,7 @@ CONTAINS
     CHARACTER(LEN=255)        :: Char1
     CHARACTER(LEN=255)        :: Char2
     CHARACTER(LEN=255)        :: LOC, MSG 
-    CHARACTER(LEN=255)        :: LINE
+    CHARACTER(LEN=OPTLEN)        :: LINE
 
     ! Arrays
     INTEGER                   :: SplitInts(255)
@@ -998,7 +998,7 @@ CONTAINS
 !
     LOGICAL,          INTENT(IN)    :: am_I_Root   ! root CPU?
     INTEGER,          INTENT(IN)    :: STAT        ! 
-    CHARACTER(LEN=*), INTENT(IN)    :: LINE        ! 
+    CHARACTER(LEN=OPTLEN), INTENT(IN)    :: LINE        ! 
 !
 ! !INPUT/OUTPUT PARAMETERS:
 !
@@ -1496,7 +1496,7 @@ CONTAINS
     LOGICAL               :: Enabled, NewExt
     CHARACTER(LEN=255)    :: LOC
     CHARACTER(LEN=1023)   :: OPTS
-    CHARACTER(LEN=2047)   :: LINE
+    CHARACTER(LEN=OPTLEN)   :: LINE
     CHARACTER(LEN=2047)   :: SUBSTR(255), SPECS(255)
 
     !======================================================================
@@ -1666,7 +1666,7 @@ CONTAINS
     INTEGER               :: I, N, POS
     INTEGER               :: verb
     INTEGER               :: warn
-    CHARACTER(LEN=255)    :: LINE, LOC
+    CHARACTER(LEN=OPTLEN)    :: LINE, LOC
     CHARACTER(LEN=255)    :: LogFile
     CHARACTER(LEN=255)    :: DiagnPrefix
     LOGICAL               :: FOUND
@@ -2812,7 +2812,7 @@ CONTAINS
 ! !LOCAL VARIABLES:
 !
     INTEGER               :: N, OPT, STRLEN, RC
-    CHARACTER(LEN=255)    :: LINE
+    CHARACTER(LEN=OPTLEN)    :: LINE
     CHARACTER(LEN=255)    :: SUBSTR(255) 
     LOGICAL               :: EOF
 
@@ -2959,7 +2959,7 @@ CONTAINS
 !
 ! !INPUT PARAMETERS:
 !
-    CHARACTER(LEN=255), INTENT(IN   )    :: LINE 
+    CHARACTER(LEN=OPTLEN), INTENT(IN   )    :: LINE 
     CHARACTER(LEN=255), INTENT(IN   )    :: SUBSTR(255) 
     INTEGER,            INTENT(IN   )    :: N
     INTEGER,            INTENT(IN   )    :: chrcl
@@ -3015,7 +3015,7 @@ CONTAINS
 ! !INPUT PARAMETERS:
 !
     TYPE(Ext),          POINTER          :: ExtList
-    CHARACTER(LEN=255), INTENT(IN   )    :: LINE 
+    CHARACTER(LEN=OPTLEN), INTENT(IN   )    :: LINE 
     CHARACTER(LEN=255), INTENT(IN   )    :: SUBSTR(255) 
     INTEGER,            INTENT(IN   )    :: N
     INTEGER,            INTENT(IN   )    :: intcl

--- a/HEMCO/Core/hco_diagn_mod.F90
+++ b/HEMCO/Core/hco_diagn_mod.F90
@@ -381,7 +381,7 @@ CONTAINS
                      OptValChar=OutTimeStampChar, FOUND=FOUND, RC=RC )
     IF ( RC /= HCO_SUCCESS ) RETURN
     IF ( .NOT. FOUND ) THEN
-       OutTimeStamp = HcoDiagnEnd
+       OutTimeStamp = HcoDiagnStart
     ELSE
        CALL TRANLC( OutTimeStampChar )
        IF (     TRIM(OutTimeStampChar) == 'start' ) THEN
@@ -395,9 +395,9 @@ CONTAINS
 
        ELSE
           WRITE(MSG,*) 'Unrecognized output time stamp location: ', &
-             TRIM(OutTimeStampChar), ' - will use default (end)'
+             TRIM(OutTimeStampChar), ' - will use default (start)'
           CALL HCO_WARNING(HcoState%Config%Err,MSG,RC,THISLOC=LOC,WARNLEV=1)
-          OutTimeStamp = HcoDiagnEnd
+          OutTimeStamp = HcoDiagnStart
        ENDIF 
     ENDIF
 
@@ -4473,7 +4473,7 @@ CONTAINS
 ! !LOCAL VARIABLES:
 !
     INTEGER             :: N
-    CHARACTER(LEN=255)  :: LINE
+    CHARACTER(LEN=OPTLEN)  :: LINE
     CHARACTER(LEN=255)  :: MSG
     CHARACTER(LEN=255)  :: SUBSTR(255) 
     CHARACTER(LEN=255)  :: LOC = 'DiagnFileGetNext (hco_diagn_mod.F90)'

--- a/HEMCO/Core/hco_extlist_mod.F90
+++ b/HEMCO/Core/hco_extlist_mod.F90
@@ -83,7 +83,7 @@ MODULE HCO_ExtList_Mod
 !
 ! !PRIVATE TYPES:
 !
-  ! Lenght of maximum token character length
+  ! Length of maximum token character length
   CHARACTER(LEN=OPTLEN), PARAMETER  :: EMPTYOPT = '---'
 
   !---------------------------------------------------------------------------

--- a/HEMCO/Core/hco_types_mod.F90
+++ b/HEMCO/Core/hco_types_mod.F90
@@ -35,7 +35,7 @@ MODULE HCO_TYPES_MOD
 ! !PUBLIC PARAMETERS:
 !
   ! Maximum length of option name
-  INTEGER, PARAMETER       :: OPTLEN = 1023
+  INTEGER, PARAMETER       :: OPTLEN = 10000
 
   ! Cycle flags. Used to determine the temporal behavior of data
   ! fields. For example, data set to 'cycle' will be recycled if

--- a/HEMCO/Core/hcoio_read_std_mod.F90
+++ b/HEMCO/Core/hcoio_read_std_mod.F90
@@ -3128,8 +3128,8 @@ CONTAINS
     INTEGER,  ALLOCATABLE :: CIDS(:,:)
     REAL(hp), POINTER     :: Vals(:)
     LOGICAL               :: Verb
-    CHARACTER(LEN=2047)   :: LINE
-    CHARACTER(LEN=255)    :: MSG, DUM, CNT
+    CHARACTER(LEN=10000)   :: LINE
+    CHARACTER(LEN=10000)    :: MSG, DUM, CNT
     CHARACTER(LEN=255)    :: LOC = 'HCOIO_ReadCountryValues (hcoio_dataread_mod.F90)'
 
     !======================================================================

--- a/HEMCO/Extensions/Makefile
+++ b/HEMCO/Extensions/Makefile
@@ -152,7 +152,7 @@ hcox_driver_mod.o           : hcox_driver_mod.F90             \
 
 
 hcox_dustdead_mod.o         : hcox_dustdead_mod.F             \
-                              hcox_state_mod.o		      
+                              hcox_state_mod.o		          
 
 hcox_dustginoux_mod.o       : hcox_dustginoux_mod.F90         \
                               hcox_state_mod.o		      

--- a/HEMCO/Extensions/hcox_aerocom_mod.F90
+++ b/HEMCO/Extensions/hcox_aerocom_mod.F90
@@ -19,6 +19,7 @@ MODULE HCOX_AeroCom_Mod
 !
   USE HCO_Error_MOD
   USE HCO_Diagn_MOD
+  USE HCO_Types_Mod
   USE HCOX_TOOLS_MOD
   USE HCOX_State_MOD, ONLY : Ext_State
   USE HCO_State_MOD,  ONLY : HCO_State 
@@ -436,7 +437,7 @@ CONTAINS
     REAL(hp), ALLOCATABLE :: VolcLon(:)      ! Volcano longitude [deg E]
     REAL(hp), ALLOCATABLE :: VolcLat(:)      ! Volcano latitude  [deg N]
     LOGICAL               :: FileExist, EOF
-    CHARACTER(LEN=255)    :: ThisFile, ThisLine
+    CHARACTER(LEN=OPTLEN)    :: ThisFile, ThisLine
     CHARACTER(LEN=255)    :: MSG 
     CHARACTER(LEN=255)    :: LOC = 'ReadVolcTable (hcox_aerocom_mod.F90)' 
 

--- a/HEMCO/Extensions/hcox_dustdead_mod.F
+++ b/HEMCO/Extensions/hcox_dustdead_mod.F
@@ -182,6 +182,9 @@
       ! Fixed-size grid information
       INTEGER, PARAMETER   :: DST_SRC_NBR      = 3
       INTEGER, PARAMETER   :: MVT              = 14
+
+      ! New emission scheme settings
+      LOGICAL, PARAMETER     :: LKOKDIST = .TRUE.
       CONTAINS
 !EOC
 !------------------------------------------------------------------------------
@@ -1495,7 +1498,8 @@
      &    WND_FRC_SLT,       ! O [m s-1] Saltating friction velocity
      &    WND_RFR,           ! I [m s-1] Wind speed at reference height
      &    WND_RFR_THR_SLT )  ! I [m s-1] Thresh. 10 m wind speed for saltation
-
+      
+      IF (LKOKDIST.EQ..FALSE.) THEN
       !=================================================================
       ! Compute horizontal streamwise mass flux, Zender et al., expr. (10)
       !=================================================================
@@ -1507,7 +1511,6 @@
                                !                streamwise mass flux
      &    WND_FRC_SLT,         ! I [m s-1] Saltating friction velocity
      &    WND_FRC_THR_SLT )    ! I [m s-1] Threshold friction vel for saltation
-
 !-----------------------------------------------------------------------------
 ! Prior to 1/25/07:
 ! We now multiply by the GOCART source function, and we will ignore
@@ -1531,13 +1534,6 @@
       ! The vegetation effect has been eliminated in LND_FRC_MBL_GET
       ! and we also ignore MBL_BSN_FCT. (tdf, bmy, 1/25/07)
       DO I = 1, HcoState%NX     
-       IF (FLX_MSS_HRZ_SLT_TTL(I).GT.0.0d0) THEN
-       write(*,*) "HFLX",FLX_MSS_HRZ_SLT_TTL(I),DNS_MDP(I),
-     &            TPT_MDP(I),PRS_MDP(I),Q_H2O_VPR(I),
-     &            WND_FRC_THR_SLT(I),WND_FRC_SLT(I),
-     &            LND_FRC_MBL_SLICE(i),Inst%FLX_MSS_FDG_FCT,
-     &            SRCE_FUNC_SLICE(I)
-       ENDIF
          FLX_MSS_HRZ_SLT_TTL(I) = FLX_MSS_HRZ_SLT_TTL(I) ! [kg m-2 s-1]
      &       * LND_FRC_MBL_SLICE(i)   ! [frc] Bare ground fraction
      &       * Inst%FLX_MSS_FDG_FCT   ! [frc] Global mass flux tuning
@@ -1555,7 +1551,28 @@
                                !            streamwise mass flux
      &    FLX_MSS_VRT_DST_TTL, ! O [kg/m2/s] Total vertical mass flux of dust
      &    MSS_FRC_CLY_SLICE )  ! I [frc] Mass fraction clay
-      
+      ELSE
+       !=================================================================
+       ! Compute vertical dust mass flux, see Kok et al., 2013 DAR
+       ! 04/2018
+       !=================================================================
+        CALL FLX_MSS_VRT_TTL_KOK13_GET(
+     &    HcoState,
+     &    DNS_MDP,             ! I [kg m-3] Midlayer density
+     &    FLG_MBL_SLICE,       ! I [flg] Mobilization candidate flag
+     &    FLX_MSS_VRT_DST_TTL, ! O [kg m-1 s-1] Vertically integrated streamwise mass flux
+     &    WND_FRC_SLT,         ! I [m s-1] Saltating friction velocity
+     &    WND_RFR,             ! I [m s-1] Wind speed at reference height
+     &    WND_FRC_THR_SLT,     ! I [m s-1] Threshold friction vel for saltation
+     &    MSS_FRC_CLY_SLICE)   ! I [frc] Mass fraction of clay
+
+        DO I = 1, HcoState%NX
+         FLX_MSS_VRT_DST_TTL(I) = FLX_MSS_VRT_DST_TTL(I) ! [kg m-2 s-1]
+     &       * LND_FRC_MBL_SLICE(i)   ! [frc] Bare ground fraction
+     &       * Inst%FLX_MSS_FDG_FCT   ! [frc] Global mass flux tuning
+        ENDDO
+       ENDIF
+
       !=================================================================
       ! Now, partition vertical dust mass flux into transport bins
       !
@@ -1566,8 +1583,8 @@
      &    HcoState%NX, 
      &    FLG_MBL_SLICE,       ! I [flg] Mobilization candidate flag
      &    FLX_MSS_VRT_DST,     ! O [kg m-2 s-1] Vertical mass flux of dust
-     &    FLX_MSS_VRT_DST_TTL) ! I [kg m-2 s-1] Total vertical mass flux of dus
-
+     &    FLX_MSS_VRT_DST_TTL, ! I [kg m-2 s-1] Total vertical mass flux of dus
+     &    LKOKDIST)
       !=================================================================
       ! Mask dust mass flux by tracer mass fraction at source
       !=================================================================
@@ -3695,8 +3712,9 @@
             !===========================================================
 
             ! [m3 m-3]
-            GWC_THR(LON_IDX) = 0.17D0 + 0.14D0* MSS_FRC_CLY_SLC(LON_IDX)
-
+!            GWC_THR(LON_IDX) = 0.17D0 + 0.14D0* MSS_FRC_CLY_SLC(LON_IDX)
+            GWC_THR(LON_IDX)=3.0d0*MSS_FRC_CLY_SLC(LON_IDX)*
+     &                       (0.17D0+0.14D0*MSS_FRC_CLY_SLC(LON_IDX))
             IF ( GWC_SFC(LON_IDX) > GWC_THR(LON_IDX) )
      &           FRC_THR_NCR_WTR(LON_IDX) = SQRT(1.0D0+1.21D0
      &           * (100.0D0 * (GWC_SFC(LON_IDX)-GWC_THR(LON_IDX)))
@@ -4296,6 +4314,126 @@
 
 !------------------------------------------------------------------------------
 
+      SUBROUTINE FLX_MSS_VRT_TTL_KOK13_GET( HcoState, DNS_MDP, FLG_MBL,
+     &                                VRT_TTL, U_S, WND_RFR,U_ST,
+     &                                MSS_FRC_CLY)
+!
+!******************************************************************************
+!  Subroutine FLX_MSS_VRT_DST_TTL_KOK13_GET diagnoses total vertical
+!  mass flux without relying on horizontal saltating flux, but
+!  provides better relationship between the wind threshold and the
+!  fragmentation resistance of the soil (shown to improve agreement
+!  with
+!  in-situ measurements (Kok et al. 2013, PNAS - currently unpublished
+!  as of 4/2/13 DAR)
+!  Adapted from the implementation by Jasper Kok into the DEAD dust
+!  scheme within CESM
+!
+!  Arguments as Input:
+!  ============================================================================
+!  (1 ) DNS_MDP (REAL*8 ) : Midlayer density  [g/m3  ]
+!  (2 ) FLG_MBL (LOGICAL) : Mobilization candidate flag [flag  ]
+!  (4 ) U_S     (REAL*8 ) : Surface friction velocity [m/s   ]
+!  (5 ) U_ST    (REAL*8 ) : Threshold friction spd for saltation [m/s   ]
+!  (6 ) WND_RFR (REAL*8 ) : 10m Wind Speed [m/s   ]
+!
+!  Arguments as Output:
+!  ============================================================================
+!  (3 ) QS_TTL  (REAL*8 ) : Vertically integrated streamwise mass flux [kg/m/s]
+!******************************************************************************
+!
+
+      TYPE(HCO_State), POINTER :: HcoState
+      LOGICAL, INTENT(IN)  :: FLG_MBL(HcoState%NX)
+      REAL*8,  INTENT(IN)  :: DNS_MDP(HcoState%NX)
+      REAL*8,  INTENT(IN)  :: U_S(HcoState%NX)
+      REAL*8,  INTENT(IN)  :: U_ST(HcoState%NX)
+      REAL*8,  INTENT(IN)  :: WND_RFR(HcoState%NX)
+      REAL*8,  INTENT(OUT) :: VRT_TTL(HcoState%NX)
+      REAL*8,  INTENT(IN)  :: MSS_FRC_CLY(HcoState%NX)
+      ! Parameters
+      !------------------
+      ! [frc] Mass fraction clay limited to 0.20
+      REAL*8               :: MSS_FRC_CLY_VLD
+      REAL*8, PARAMETER    :: WND_FRC_THR_SLT_STD_MIN = 0.16D0
+      ! [m/s] minimum standardized soil threshold friction speed
+      REAL*8, parameter :: Cd0 = 4.4e-5             ! [dimless]
+      ! proportionality constant in calculation of dust emission
+      ! coefficient
+      REAL*8, parameter :: Ca = 2.7D0                 ! [dimless]
+      ! proportionality constant in scaling of dust emission exponent
+
+      REAL*8, parameter :: Ce = 2.0D0                 ! [dimless]
+       !proportionality constant scaling exponential dependence of dust
+       !emission
+       !coefficient on standardized soil threshold friction speed -jfk
+       REAL*8, parameter :: C_TUNE = 500.0D0             ! [dimless]
+       !global tuning constant for vertical dust flux; set to produce
+       !~same
+       !global dust flux in control sim (I_2000) as old parameterization
+       !-jfk
+       REAL*8, parameter :: DNS_MDP_STD = 1.2250D0    ! [kg/m3]
+       !density of air at standard pressure (101325) and temperature
+       !(293
+       !K)
+
+       ! [frc] Saltation constant Whi79 p. 4648, MaB97 p. 16422
+       REAL*8,  PARAMETER   :: CST_SLT = 2.61d0
+       ! conversion factor of 10m wind to thresh based on BLM_MBL
+       REAL*8,  PARAMETER   :: CNV_10M_THR = 0.0347436D0
+       ! number of tie points on Weibull wind distribution
+       REAL*8,  PARAMETER   :: N_U = 1000.0D0
+       !------------------
+       ! Local variables
+       !------------------
+
+       ! [frc] Ratio of wind friction threshold to wind friction
+       REAL*8               :: U_S_RAT
+       REAL*8               :: U_S0F, U_THR_LIM, U_S0_INTV
+       REAL*8               :: WND_FRC_THR_SLT_STD
+       REAL*8               :: Cd
+       REAL*8               :: PDFTOT !summation of PDF to check=1
+       REAL*8               :: FLX_FCT !factor increase in saltation
+
+       ! [idx] Counting index for lon
+       integer              :: lon_idx,U_IDX
+      ! Initialize
+      VRT_TTL(:) = 0.0D0
+
+      DO LON_IDX = 1, HcoState%NX
+        IF ( FLG_MBL(LON_IDX) .AND.
+     &        U_S(LON_IDX) > U_ST(LON_IDX) ) THEN
+
+
+         MSS_FRC_CLY_VLD = MIN(MSS_FRC_CLY(LON_IDX),0.2D0)  ! [frc]
+         ! standardized soil threshold friction speed
+         WND_FRC_THR_SLT_STD = U_ST(LON_IDX)*sqrt(DNS_MDP(LON_IDX)/
+     &                         DNS_MDP_STD)
+
+         ! New Kok et al. (2013) parameterization constant
+         ! representing soil resistance to erosion via saltation
+         ! bombardment (Kok et al., 2013, eq. 15)
+         Cd = Cd0 * exp(-Ce * (WND_FRC_THR_SLT_STD -
+     &        WND_FRC_THR_SLT_STD_MIN) / WND_FRC_THR_SLT_STD_MIN)
+!             the Cdust emission coefficient -jfk, DAR
+
+
+         VRT_TTL(LON_IDX) = VRT_TTL(LON_IDX) +  ! [kg m-1 s-1]
+     &      Cd*MSS_FRC_CLY_VLD*DNS_MDP(LON_IDX) *
+     &      ((U_S(LON_IDX)**2.0D0 - U_ST(LON_IDX)**2.0D0) /
+     &      WND_FRC_THR_SLT_STD) *
+     &      (U_S(LON_IDX)/U_ST(LON_IDX))**(Ca*(WND_FRC_THR_SLT_STD -
+     &      WND_FRC_THR_SLT_STD_MIN) / WND_FRC_THR_SLT_STD_MIN)
+         ! apply tuning to scale to match previous emissions
+         ! currently using Kok value for CESM tuning which involves
+         ! reducing by 95% 
+         VRT_TTL(LON_IDX) = VRT_TTL(LON_IDX)*C_TUNE
+        ENDIF
+       ENDDO
+      ! Return to calling program
+      END SUBROUTINE FLX_MSS_VRT_TTL_KOK13_GET
+!------------------------------------------------------------------------------
+
       SUBROUTINE DST_PSD_MSS( OVR_SRC_SNK_FRC, MSS_FRC_SRC,
      &                        OVR_SRC_SNK_MSS, NBINS, DST_SRC_NBR )
 !
@@ -4385,7 +4523,8 @@
 
       SUBROUTINE FLX_MSS_VRT_DST_PRT( Inst, NX, FLG_MBL,
      &                                FLX_MSS_VRT_DST,
-     &                                FLX_MSS_VRT_DST_TTL )
+     &                                FLX_MSS_VRT_DST_TTL,
+     &                                LKOKDIST )
 !
 !******************************************************************************
 !  Subroutine FLX_MSS_VRT_DST_PRT partitions total vertical mass flux of dust
@@ -4416,12 +4555,20 @@
       LOGICAL, INTENT(IN)   :: FLG_MBL(NX)
       REAL*8,  INTENT(IN)   :: FLX_MSS_VRT_DST_TTL(NX)
       REAL*8,  INTENT(OUT)  :: FLX_MSS_VRT_DST(NX,NBINS)
+      LOGICAL, INTENT(IN)   :: LKOKDIST
 
       ! Local variables
       INTEGER               :: LON_IDX   ! [idx] Counting index for lon
       INTEGER               :: SRC_IDX   ! [idx] Counting index for src
       INTEGER               :: SNK_IDX   ! [idx] Counting index for snk
       INTEGER               :: SNK_NBR   ! [nbr] Dimension size
+      REAL*8                :: KOK_DIST_SRC_FRC(4)
+
+      !assuming all emitted mass is simulated
+!      KOK_DIST_SRC_FRC = (/0.0509d0,0.1244d0,0.2565d0,0.5682d0/)
+      !assuming only the fraction within the size bin ranges is
+      !simulated
+      KOK_DIST_SRC_FRC = (/0.0435d0,0.1062d0,0.2190d0,0.4851d0/)
 
       !=================================================================
       ! FLX_MSS_VRT_DST_PRT begins here!
@@ -4438,12 +4585,18 @@
 
             ! Loop over source & sink indices
             DO SNK_IDX = 1, NBINS
-            DO SRC_IDX = 1, DST_SRC_NBR
+            IF(LKOKDIST.EQ..FALSE.) THEN
+             DO SRC_IDX = 1, DST_SRC_NBR
                FLX_MSS_VRT_DST(LON_IDX,SNK_IDX) = ! [kg m-2 s-1]
      &              FLX_MSS_VRT_DST(LON_IDX,SNK_IDX)
      &              + Inst%OVR_SRC_SNK_MSS(SRC_IDX,SNK_IDX)
      &              * FLX_MSS_VRT_DST_TTL(LON_IDX)
-            ENDDO
+             ENDDO
+            ELSE
+             FLX_MSS_VRT_DST(LON_IDX,SNK_IDX) =
+     &       KOK_DIST_SRC_FRC(SNK_IDX) *
+     &       FLX_MSS_VRT_DST_TTL(LON_IDX)
+            ENDIF
             ENDDO
          ENDIF
       ENDDO

--- a/HEMCO/Extensions/hcox_dustdead_mod.F
+++ b/HEMCO/Extensions/hcox_dustdead_mod.F
@@ -182,7 +182,8 @@
       ! Fixed-size grid information
       INTEGER, PARAMETER   :: DST_SRC_NBR      = 3
       INTEGER, PARAMETER   :: MVT              = 14
-
+      !this needs adding to input file switches (or based on settings)
+      LOGICAL, PARAMETER     :: LONLINEDUST = .TRUE.
       CONTAINS
 !EOC
 !------------------------------------------------------------------------------
@@ -206,6 +207,16 @@
       USE HCO_FLUXARR_MOD,   ONLY : HCO_EmisAdd 
       USE HCO_CLOCK_MOD,     ONLY : HcoClock_Get
       USE HCO_CLOCK_MOD,     ONLY : HcoClock_First
+      USE Input_Opt_Mod,     ONLY : OptInput
+      USE CMN_SIZE_MOD                        ! Size parameters
+      USE TIME_MOD                            ! Date & time routines
+! NcdfUtil modules for netCDF I/O
+      USE m_netcdf_io_open                    ! netCDF open
+      USE m_netcdf_io_get_dimlen              ! netCDF dimension queries
+      USE m_netcdf_io_read                    ! netCDF data reads
+      USE m_netcdf_io_close                   ! netCDF close
+
+      TYPE(OptInput), POINTER    :: Input_Opt  ! Input Options object
 !
 ! !INPUT PARAMETERS:
 !
@@ -286,6 +297,16 @@
       REAL*8, PARAMETER      :: AKAP    = RGAS     / CP
       REAL*8, PARAMETER      :: P1000   = 1000d0
       CHARACTER(LEN=255)     :: MSG
+! OFFLINE DUST PARAMETERS      
+      INTEGER                :: fA1          ! netCDF file ID
+      INTEGER                :: X, Y, T      ! netCDF file dimensions
+      INTEGER                :: YYYYMMDD, HHMMSS, cYr,cMt,cDy,cHr
+      INTEGER                :: II, JJ, TIME_INDEX
+      CHARACTER(LEN=255)     :: dir,nc_file,v_name
+      CHARACTER(LEN=4)       :: Yrs, Mts, Dys, hrs
+      CHARACTER(LEN=2)       :: STRBIN
+      INTEGER                :: st3d(3), ct3d(3)   ! Start + count, for 3D arrays
+      REAL*4                 :: Q(IIPAR,JJPAR)     ! Temporary data arrray
 
       !=================================================================
       ! HCOX_DUSTDEAD_RUN begins here!
@@ -293,7 +314,7 @@
 
       ! Return if extension disabled 
       IF ( ExtState%DustDead <= 0 ) RETURN
-
+      
       ! Enter
       CALL HCO_ENTER( HcoState%Config%Err, 
      &               'HCOX_DustDead_Run (hcox_dustdead_mod.F90)', RC )
@@ -310,6 +331,10 @@
        CALL HCO_ERROR(HcoState%Config%Err,MSG,RC)
        RETURN
       ENDIF
+
+      !We now have a flag for offline dust
+      !may want to turn this into a compiler/input switch at some point
+      IF(LONLINEDUST.EQ..TRUE.) THEN
 
       !=================================================================
       ! Get pointers to gridded data imported through config. file
@@ -390,11 +415,11 @@
       ! Error check
       ERR = .FALSE.
 
-!$OMP PARALLEL DO
-!$OMP+DEFAULT( SHARED )
-!$OMP+PRIVATE( I,     J,      P1,    P2,   PTHICK,  PMID, TLON        )
-!$OMP+PRIVATE( THLON, ULON,   VLON,  BHT2, Q_H2O,   ORO,  SNW_HGT_LQD )
-!$OMP+PRIVATE( N,     YMID_R, DSRC,  RC,   AREA_M2, DUST_EMI_TOTAL    )
+!!!$OMP PARALLEL DO
+!!!$OMP+DEFAULT( SHARED )
+!!!$OMP+PRIVATE( I,     J,      P1,    P2,   PTHICK,  PMID, TLON        )
+!!!$OMP+PRIVATE( THLON, ULON,   VLON,  BHT2, Q_H2O,   ORO,  SNW_HGT_LQD )
+!!!$OMP+PRIVATE( N,     YMID_R, DSRC,  RC,   AREA_M2, DUST_EMI_TOTAL    )
 
       ! Loop over latitudes
       DO J = 1, HcoState%NY 
@@ -417,6 +442,7 @@
 
             ! Temperature [K] at midpoint of surface layer 
             TLON(I)        = ExtState%TK%Arr%Val(I,J,1)
+!            TLON(I)        = ExtState%TMPU1%Arr%Val(I,J,1)
 
             ! Potential temperature [K] at midpoint 
             THLON(I)       = TLON(I) * ( P1000 / PMID(I) )**AKAP
@@ -439,7 +465,7 @@
             ! Snow [m H2O]. SNOWHGT is in kg H2O/m2, which is equivalent to
             ! mm H2O. Convert to m H2O here.
             SNW_HGT_LQD(I) = ExtState%SNOWHGT%Arr%Val(I,J) / 1000.d0
-
+!            write(6,*) "dud",I,Q_H2O(I),PMID(I),TLON(I),ULON(I),VLON(I)
             ! Dust tracer and increments
             DSRC(I,:) = 0.0d0
          ENDDO !I
@@ -485,6 +511,9 @@
 
                IF ( Inst%HcoIDs(N) > 0 ) THEN
                   FLUX(I,J,N) = ( DSRC(I,N) / AREA_M2 / DTSRCE )
+                  IF ((N.EQ.2).AND.(FLUX(I,J,N).GT.0d0)) THEN
+                   write(6,*) "DFLX:",I,J,N,FLUX(I,J,N)
+                  ENDIF
                ENDIF
 
                ! Include DUST Alkalinity SOURCE, assuming an alkalinity
@@ -498,13 +527,89 @@
             ENDDO !N
          ENDDO !I
       ENDDO !J 
-!$OMP END PARALLEL DO
+!!!$OMP END PARALLEL DO
 
-      ! Error check 
-      IF ( ERR ) THEN
-         RC = HCO_FAIL
-         RETURN 
-      ENDIF
+      ! Error check
+       IF ( ERR ) THEN
+          RC = HCO_FAIL
+          RETURN
+       ENDIF
+
+      ELSE 
+        !Read the offline emissions for the current hour
+        !Format to FLUX to match what the following code expects
+        ! Get emissions time step
+        DTSRCE = HcoState%TS_EMIS
+        CALL HcoClock_Get( am_I_Root, HcoState%Clock,
+     &                    cYYYY=cYr, cMM=cMt, cDD=cDy,
+     &                    cH=cHr, RC=RC )
+        YYYYMMDD  = cYr*10000 + cMt*100 + cDy
+        HHMMSS    = cHr*10000
+
+        ! Write datetime
+        WRITE( Yrs, '(i4.4)' ) cYr
+        WRITE( Mts, '(i2.2)' ) cMt
+        WRITE( Dys, '(i2.2)' ) cDy
+        WRITE( hrs, '(i2.2)' ) cHr
+        
+        ! replace time & date tokens in the file name
+        dir     = 'offline_dust/' // trim(Yrs) // '/'
+
+        ! Replace time & date tokens in the file name
+        nc_file = 'HEMCO_sa.diagnostics.' // trim(Yrs) // trim(Mts)
+     &            // trim(Dys) // trim(hrs) // '00.nc'
+
+        ! Construct complete file path
+        nc_file = TRIM( '/net/seurat/data/ctm/' ) // 
+     &            TRIM( dir ) // TRIM( nc_file )
+        write(6,*) 'dustnc: ',nc_file
+        ! Open netCDF file
+        CALL NcOp_Rd( fA1, TRIM( nc_file ) )
+
+        ! Read the dimensions from the netCDF file
+        CALL NcGet_DimLen( fA1, 'lon',   X )
+        CALL NcGet_DimLen( fA1, 'lat',   Y )
+        CALL NcGet_DimLen( fA1, 'time',  T )
+        write(6,*) 'dustdim: ',X,Y,T
+       !======================================================================
+       ! Read data from the netCDF file
+       !======================================================================
+       ! Find the proper time-slice to read from disk
+       time_index = ( HHMMSS / 10000 ) + 1
+
+       ! netCDF start & count indices
+       st3d      = (/ 1,     1,     1          /)
+       ct3d      = (/ IIPAR, JJPAR, 1          /)
+
+       ! Read emissions
+       DO N=1, 4
+        WRITE(STRBIN,'(I1)') N
+        v_name = "EMIS_DST" // TRIM(STRBIN)
+        CALL NcRd( Q, fA1, TRIM(v_name), st3d, ct3d )
+
+       !======================================================================
+       ! Regrid the NC data if necessary (might be high res)
+       !======================================================================
+!        CALL REGRID_MAPA2A ( am_I_Root, HcoState, NcArr, LonE, LatE,
+!     &                       CLct, RC )
+!
+
+
+        DO II=1,IIPAR
+        DO JJ=1,JJPAR
+         AREA_M2 = HcoState%Grid%AREA_M2%Val(II,JJ)
+         !emission timestep is 20min but the offline emissions
+         !are hourly, so fix to 60min when converting to kg/m2/s
+         !now saving out as kg/m2/s so no conversion needed here.
+         FLUX(II,JJ,N) = Q(II,JJ) !/ AREA_M2 / 3600d0
+         IF ((N.EQ.2).AND.(FLUX(II,JJ,N).GT.0d0)) THEN
+          write(6,*) 'DFLX:',II,JJ,N,FLUX(II,JJ,N)
+         ENDIF
+        ENDDO
+        ENDDO 
+       ENDDO
+       CALL NcCl( fA1 )
+      ENDIF !LONLINEDUST
 
       !=================================================================
       ! PASS TO HEMCO STATE AND UPDATE DIAGNOSTICS 
@@ -913,6 +1018,7 @@
       ! Activate met fields used by this extension
       ExtState%SPHU%DoUse    = .TRUE.
       ExtState%TK%DoUse      = .TRUE.
+!      ExtState%TMPU1%DoUse   = .TRUE.
       ExtState%U10M%DoUse    = .TRUE.
       ExtState%V10M%DoUse    = .TRUE.
       ExtState%T2M%DoUse     = .TRUE.
@@ -5660,6 +5766,9 @@ c Fix up for negative argument, erf, etc.
       RETURN
 
 #endif
+!      IF (LONLINEDUST.EQ..FALSE.) THEN 
+       FLX_MSS_FDG_FCT = 1.0d0
+!      ENDIF
 
       ! Return to calling program
       END FUNCTION HCOX_DustDead_GetFluxTun

--- a/HEMCO/Extensions/hcox_dustdead_mod.F
+++ b/HEMCO/Extensions/hcox_dustdead_mod.F
@@ -442,7 +442,7 @@
 
             ! Temperature [K] at midpoint of surface layer 
             TLON(I)        = ExtState%TK%Arr%Val(I,J,1)
-!            TLON(I)        = ExtState%TMPU1%Arr%Val(I,J,1)
+!            TLON(I)        = ExtState%T2M%Arr%Val(I,J)
 
             ! Potential temperature [K] at midpoint 
             THLON(I)       = TLON(I) * ( P1000 / PMID(I) )**AKAP
@@ -465,9 +465,9 @@
             ! Snow [m H2O]. SNOWHGT is in kg H2O/m2, which is equivalent to
             ! mm H2O. Convert to m H2O here.
             SNW_HGT_LQD(I) = ExtState%SNOWHGT%Arr%Val(I,J) / 1000.d0
-!            write(6,*) "dud",I,Q_H2O(I),PMID(I),TLON(I),ULON(I),VLON(I)
             ! Dust tracer and increments
             DSRC(I,:) = 0.0d0
+
          ENDDO !I
 
          !==============================================================
@@ -511,9 +511,6 @@
 
                IF ( Inst%HcoIDs(N) > 0 ) THEN
                   FLUX(I,J,N) = ( DSRC(I,N) / AREA_M2 / DTSRCE )
-                  IF ((N.EQ.2).AND.(FLUX(I,J,N).GT.0d0)) THEN
-                   write(6,*) "DFLX:",I,J,N,FLUX(I,J,N)
-                  ENDIF
                ENDIF
 
                ! Include DUST Alkalinity SOURCE, assuming an alkalinity
@@ -1565,6 +1562,9 @@
       ! Adjust threshold friction velocity to account
       ! for moisture and roughness
       DO I = 1, HcoState%NX
+!       write(*,*) "WTHR",WND_FRC_THR_SLT(i),FRC_THR_NCR_WTR(i),
+!     &            FRC_THR_NCR_DRG(i)
+
          WND_FRC_THR_SLT(I) =      ! [m s-1] Threshold friction velocity
                                    !         for saltation
      &        WND_FRC_THR_SLT(i)   ! [m s-1] Threshold for dry, flat ground
@@ -1630,13 +1630,20 @@
       ! Now simply multiply by the GOCART source function.
       ! The vegetation effect has been eliminated in LND_FRC_MBL_GET
       ! and we also ignore MBL_BSN_FCT. (tdf, bmy, 1/25/07)
-      DO I = 1, HcoState%NX
+      DO I = 1, HcoState%NX     
+      IF (FLX_MSS_HRZ_SLT_TTL(I).GT.0.0d0) THEN
+!       write(*,*) "HFLX",FLX_MSS_HRZ_SLT_TTL(I),DNS_MDP(I),
+!     &            TPT_MDP(I),PRS_MDP(I),Q_H2O_VPR(I),
+!     &            WND_FRC_THR_SLT(I),WND_FRC_SLT(I),
+!     &            LND_FRC_MBL_SLICE(i),Inst%FLX_MSS_FDG_FCT,
+!     &            SRCE_FUNC_SLICE(I)
+      ENDIF
+
          FLX_MSS_HRZ_SLT_TTL(I) = FLX_MSS_HRZ_SLT_TTL(I) ! [kg m-2 s-1]
      &       * LND_FRC_MBL_SLICE(i)   ! [frc] Bare ground fraction
      &       * Inst%FLX_MSS_FDG_FCT   ! [frc] Global mass flux tuning
      &       * SRCE_FUNC_SLICE(I)     ! GOCART source function
       ENDDO
-
       !=================================================================
       ! Compute vertical dust mass flux, see Zender et al., expr. (11).
       !=================================================================
@@ -1649,7 +1656,7 @@
                                !            streamwise mass flux
      &    FLX_MSS_VRT_DST_TTL, ! O [kg/m2/s] Total vertical mass flux of dust
      &    MSS_FRC_CLY_SLICE )  ! I [frc] Mass fraction clay
-
+      
       !=================================================================
       ! Now, partition vertical dust mass flux into transport bins
       !
@@ -1694,7 +1701,10 @@
                ! what GEOS-CHEM wants is an increment in kg...So,
                ! multiply by DXYP [m2] and tm_adj [sec]
                !========================================================
-
+      IF ((FLX_MSS_VRT_DST(I,M).GT.0.0d0).AND.(M.EQ.2)) THEN
+!       write(*,*) "VFLX",FLX_MSS_VRT_DST(I,M),
+!     &           HcoState%Grid%AREA_M2%Val(I,LAT_IDX),TM_ADJ
+      ENDIF
                ! [kg/sec]
                Q_DST_TND_MBL(I,M) = FLX_MSS_VRT_DST(I,M)
      &            *HcoState%Grid%AREA_M2%Val(I,LAT_IDX)
@@ -3577,6 +3587,8 @@
 
          ! Added mobilisation constraint
          IF ( FLG_MBL(LON_IDX) ) THEN
+!            write(*,*) "THRS",LON_IDX,DNS_SLT,GRV_SFC,DMT_SLT_OPT,
+!     &        DNS_MDP(LON_IDX),DMT_SLT_OPT
             WND_FRC_THR_SLT(LON_IDX) =  SQRT(TMP1) * SQRT(ALPHA) ! [m s-1]
          ENDIF
       ENDDO
@@ -5669,6 +5681,8 @@ c Fix up for negative argument, erf, etc.
       FLX_MSS_FDG_FCT = 7.0d-4 * 1.1898d0
 
 #elif defined( MERRA2 ) && defined( GRID05x0625 )
+      !default
+      FLX_MSS_FDG_FCT = 4.9d-4 * 0.971141
 
 #if defined(NESTED_AS)
 
@@ -5728,7 +5742,6 @@ c Fix up for negative argument, erf, etc.
       !----------------------------------------------------------------
       FLX_MSS_FDG_FCT = 4.9d-4 * 0.971141
 
-
 #elif defined( MERRA2 ) && defined( GRID4x5 )
 
       !----------------------------------------------------------------
@@ -5767,7 +5780,7 @@ c Fix up for negative argument, erf, etc.
 
 #endif
 !      IF (LONLINEDUST.EQ..FALSE.) THEN 
-       FLX_MSS_FDG_FCT = 1.0d0
+!       FLX_MSS_FDG_FCT = 1.0d0
 !      ENDIF
 
       ! Return to calling program

--- a/HEMCO/Extensions/hcox_dustdead_mod.F
+++ b/HEMCO/Extensions/hcox_dustdead_mod.F
@@ -415,8 +415,12 @@
             PTHICK(I)      = ( P1 - P2 ) 
 
             ! Pressure at midpt of surface layer [Pa]
+#if defined( GEOS_FP )
+!           needs x100 as in hPa 
+            PMID(I)        = 100.0d0*( P1 + P2 ) / 2.0_hp
+#else
             PMID(I)        = ( P1 + P2 ) / 2.0_hp
-
+#endif
             ! Temperature [K] at midpoint of surface layer 
             TLON(I)        = ExtState%TK%Arr%Val(I,J,1)
 
@@ -427,7 +431,6 @@
             ! --> These variables won't be used at all...
             ULON(I)        = ExtState%U10M%Arr%Val(I,J)
             VLON(I)        = ExtState%V10M%Arr%Val(I,J)
- 
             ! Half box height at surface [m]
             BHT2(I)        = HcoState%Grid%BXHEIGHT_M%Val(I,J,1) / 2.d0
 
@@ -1461,8 +1464,6 @@
       ! Adjust threshold friction velocity to account
       ! for moisture and roughness
       DO I = 1, HcoState%NX
-!       write(*,*) "WTHR",WND_FRC_THR_SLT(i),FRC_THR_NCR_WTR(i),
-!     &            FRC_THR_NCR_DRG(i)
 
          WND_FRC_THR_SLT(I) =      ! [m s-1] Threshold friction velocity
                                    !         for saltation
@@ -1530,14 +1531,13 @@
       ! The vegetation effect has been eliminated in LND_FRC_MBL_GET
       ! and we also ignore MBL_BSN_FCT. (tdf, bmy, 1/25/07)
       DO I = 1, HcoState%NX     
-      IF (FLX_MSS_HRZ_SLT_TTL(I).GT.0.0d0) THEN
-!       write(*,*) "HFLX",FLX_MSS_HRZ_SLT_TTL(I),DNS_MDP(I),
-!     &            TPT_MDP(I),PRS_MDP(I),Q_H2O_VPR(I),
-!     &            WND_FRC_THR_SLT(I),WND_FRC_SLT(I),
-!     &            LND_FRC_MBL_SLICE(i),Inst%FLX_MSS_FDG_FCT,
-!     &            SRCE_FUNC_SLICE(I)
-      ENDIF
-
+       IF (FLX_MSS_HRZ_SLT_TTL(I).GT.0.0d0) THEN
+       write(*,*) "HFLX",FLX_MSS_HRZ_SLT_TTL(I),DNS_MDP(I),
+     &            TPT_MDP(I),PRS_MDP(I),Q_H2O_VPR(I),
+     &            WND_FRC_THR_SLT(I),WND_FRC_SLT(I),
+     &            LND_FRC_MBL_SLICE(i),Inst%FLX_MSS_FDG_FCT,
+     &            SRCE_FUNC_SLICE(I)
+       ENDIF
          FLX_MSS_HRZ_SLT_TTL(I) = FLX_MSS_HRZ_SLT_TTL(I) ! [kg m-2 s-1]
      &       * LND_FRC_MBL_SLICE(i)   ! [frc] Bare ground fraction
      &       * Inst%FLX_MSS_FDG_FCT   ! [frc] Global mass flux tuning
@@ -1600,10 +1600,6 @@
                ! what GEOS-CHEM wants is an increment in kg...So,
                ! multiply by DXYP [m2] and tm_adj [sec]
                !========================================================
-      IF ((FLX_MSS_VRT_DST(I,M).GT.0.0d0).AND.(M.EQ.2)) THEN
-!       write(*,*) "VFLX",FLX_MSS_VRT_DST(I,M),
-!     &           HcoState%Grid%AREA_M2%Val(I,LAT_IDX),TM_ADJ
-      ENDIF
                ! [kg/sec]
                Q_DST_TND_MBL(I,M) = FLX_MSS_VRT_DST(I,M)
      &            *HcoState%Grid%AREA_M2%Val(I,LAT_IDX)
@@ -3486,8 +3482,6 @@
 
          ! Added mobilisation constraint
          IF ( FLG_MBL(LON_IDX) ) THEN
-!            write(*,*) "THRS",LON_IDX,DNS_SLT,GRV_SFC,DMT_SLT_OPT,
-!     &        DNS_MDP(LON_IDX),DMT_SLT_OPT
             WND_FRC_THR_SLT(LON_IDX) =  SQRT(TMP1) * SQRT(ALPHA) ! [m s-1]
          ENDIF
       ENDDO
@@ -5510,6 +5504,7 @@ c Fix up for negative argument, erf, etc.
       FLX_MSS_FDG_FCT = 7.0d-4 / 0.731d0
 
 #elif   defined( GEOS_FP ) && defined( GRID025x03125 )
+      FLX_MSS_FDG_FCT = 1.0d0
 
 #if defined(NESTED_CH)
 

--- a/HEMCO/Extensions/hcox_dustdead_mod.F
+++ b/HEMCO/Extensions/hcox_dustdead_mod.F
@@ -5580,8 +5580,9 @@ c Fix up for negative argument, erf, etc.
       FLX_MSS_FDG_FCT = 7.0d-4 * 1.1898d0
 
 #elif defined( MERRA2 ) && defined( GRID05x0625 )
-      !default
-      FLX_MSS_FDG_FCT = 4.9d-4 * 0.971141
+
+      !default for offline dust generation
+      FLX_MSS_FDG_FCT = 1.0d0 !4.9d-4 * 0.971141
 
 #if defined(NESTED_AS)
 
@@ -5678,9 +5679,6 @@ c Fix up for negative argument, erf, etc.
       RETURN
 
 #endif
-!      IF (LONLINEDUST.EQ..FALSE.) THEN 
-!       FLX_MSS_FDG_FCT = 1.0d0
-!      ENDIF
 
       ! Return to calling program
       END FUNCTION HCOX_DustDead_GetFluxTun

--- a/HEMCO/Extensions/hcox_dustdead_mod.F
+++ b/HEMCO/Extensions/hcox_dustdead_mod.F
@@ -182,8 +182,6 @@
       ! Fixed-size grid information
       INTEGER, PARAMETER   :: DST_SRC_NBR      = 3
       INTEGER, PARAMETER   :: MVT              = 14
-      !this needs adding to input file switches (or based on settings)
-      LOGICAL, PARAMETER     :: LONLINEDUST = .TRUE.
       CONTAINS
 !EOC
 !------------------------------------------------------------------------------
@@ -210,13 +208,6 @@
       USE Input_Opt_Mod,     ONLY : OptInput
       USE CMN_SIZE_MOD                        ! Size parameters
       USE TIME_MOD                            ! Date & time routines
-! NcdfUtil modules for netCDF I/O
-      USE m_netcdf_io_open                    ! netCDF open
-      USE m_netcdf_io_get_dimlen              ! netCDF dimension queries
-      USE m_netcdf_io_read                    ! netCDF data reads
-      USE m_netcdf_io_close                   ! netCDF close
-
-      TYPE(OptInput), POINTER    :: Input_Opt  ! Input Options object
 !
 ! !INPUT PARAMETERS:
 !
@@ -297,16 +288,6 @@
       REAL*8, PARAMETER      :: AKAP    = RGAS     / CP
       REAL*8, PARAMETER      :: P1000   = 1000d0
       CHARACTER(LEN=255)     :: MSG
-! OFFLINE DUST PARAMETERS      
-      INTEGER                :: fA1          ! netCDF file ID
-      INTEGER                :: X, Y, T      ! netCDF file dimensions
-      INTEGER                :: YYYYMMDD, HHMMSS, cYr,cMt,cDy,cHr
-      INTEGER                :: II, JJ, TIME_INDEX
-      CHARACTER(LEN=255)     :: dir,nc_file,v_name
-      CHARACTER(LEN=4)       :: Yrs, Mts, Dys, hrs
-      CHARACTER(LEN=2)       :: STRBIN
-      INTEGER                :: st3d(3), ct3d(3)   ! Start + count, for 3D arrays
-      REAL*4                 :: Q(IIPAR,JJPAR)     ! Temporary data arrray
 
       !=================================================================
       ! HCOX_DUSTDEAD_RUN begins here!
@@ -331,10 +312,6 @@
        CALL HCO_ERROR(HcoState%Config%Err,MSG,RC)
        RETURN
       ENDIF
-
-      !We now have a flag for offline dust
-      !may want to turn this into a compiler/input switch at some point
-      IF(LONLINEDUST.EQ..TRUE.) THEN
 
       !=================================================================
       ! Get pointers to gridded data imported through config. file
@@ -415,11 +392,11 @@
       ! Error check
       ERR = .FALSE.
 
-!!!$OMP PARALLEL DO
-!!!$OMP+DEFAULT( SHARED )
-!!!$OMP+PRIVATE( I,     J,      P1,    P2,   PTHICK,  PMID, TLON        )
-!!!$OMP+PRIVATE( THLON, ULON,   VLON,  BHT2, Q_H2O,   ORO,  SNW_HGT_LQD )
-!!!$OMP+PRIVATE( N,     YMID_R, DSRC,  RC,   AREA_M2, DUST_EMI_TOTAL    )
+!$OMP PARALLEL DO
+!$OMP+DEFAULT( SHARED )
+!$OMP+PRIVATE( I,     J,      P1,    P2,   PTHICK,  PMID, TLON        )
+!$OMP+PRIVATE( THLON, ULON,   VLON,  BHT2, Q_H2O,   ORO,  SNW_HGT_LQD )
+!$OMP+PRIVATE( N,     YMID_R, DSRC,  RC,   AREA_M2, DUST_EMI_TOTAL    )
 
       ! Loop over latitudes
       DO J = 1, HcoState%NY 
@@ -442,7 +419,6 @@
 
             ! Temperature [K] at midpoint of surface layer 
             TLON(I)        = ExtState%TK%Arr%Val(I,J,1)
-!            TLON(I)        = ExtState%T2M%Arr%Val(I,J)
 
             ! Potential temperature [K] at midpoint 
             THLON(I)       = TLON(I) * ( P1000 / PMID(I) )**AKAP
@@ -524,89 +500,13 @@
             ENDDO !N
          ENDDO !I
       ENDDO !J 
-!!!$OMP END PARALLEL DO
+!$OMP END PARALLEL DO
 
-      ! Error check
-       IF ( ERR ) THEN
-          RC = HCO_FAIL
-          RETURN
-       ENDIF
-
-      ELSE 
-        !Read the offline emissions for the current hour
-        !Format to FLUX to match what the following code expects
-        ! Get emissions time step
-        DTSRCE = HcoState%TS_EMIS
-        CALL HcoClock_Get( am_I_Root, HcoState%Clock,
-     &                    cYYYY=cYr, cMM=cMt, cDD=cDy,
-     &                    cH=cHr, RC=RC )
-        YYYYMMDD  = cYr*10000 + cMt*100 + cDy
-        HHMMSS    = cHr*10000
-
-        ! Write datetime
-        WRITE( Yrs, '(i4.4)' ) cYr
-        WRITE( Mts, '(i2.2)' ) cMt
-        WRITE( Dys, '(i2.2)' ) cDy
-        WRITE( hrs, '(i2.2)' ) cHr
-        
-        ! replace time & date tokens in the file name
-        dir     = 'offline_dust/' // trim(Yrs) // '/'
-
-        ! Replace time & date tokens in the file name
-        nc_file = 'HEMCO_sa.diagnostics.' // trim(Yrs) // trim(Mts)
-     &            // trim(Dys) // trim(hrs) // '00.nc'
-
-        ! Construct complete file path
-        nc_file = TRIM( '/net/seurat/data/ctm/' ) // 
-     &            TRIM( dir ) // TRIM( nc_file )
-        write(6,*) 'dustnc: ',nc_file
-        ! Open netCDF file
-        CALL NcOp_Rd( fA1, TRIM( nc_file ) )
-
-        ! Read the dimensions from the netCDF file
-        CALL NcGet_DimLen( fA1, 'lon',   X )
-        CALL NcGet_DimLen( fA1, 'lat',   Y )
-        CALL NcGet_DimLen( fA1, 'time',  T )
-        write(6,*) 'dustdim: ',X,Y,T
-       !======================================================================
-       ! Read data from the netCDF file
-       !======================================================================
-       ! Find the proper time-slice to read from disk
-       time_index = ( HHMMSS / 10000 ) + 1
-
-       ! netCDF start & count indices
-       st3d      = (/ 1,     1,     1          /)
-       ct3d      = (/ IIPAR, JJPAR, 1          /)
-
-       ! Read emissions
-       DO N=1, 4
-        WRITE(STRBIN,'(I1)') N
-        v_name = "EMIS_DST" // TRIM(STRBIN)
-        CALL NcRd( Q, fA1, TRIM(v_name), st3d, ct3d )
-
-       !======================================================================
-       ! Regrid the NC data if necessary (might be high res)
-       !======================================================================
-!        CALL REGRID_MAPA2A ( am_I_Root, HcoState, NcArr, LonE, LatE,
-!     &                       CLct, RC )
-!
-
-
-        DO II=1,IIPAR
-        DO JJ=1,JJPAR
-         AREA_M2 = HcoState%Grid%AREA_M2%Val(II,JJ)
-         !emission timestep is 20min but the offline emissions
-         !are hourly, so fix to 60min when converting to kg/m2/s
-         !now saving out as kg/m2/s so no conversion needed here.
-         FLUX(II,JJ,N) = Q(II,JJ) !/ AREA_M2 / 3600d0
-         IF ((N.EQ.2).AND.(FLUX(II,JJ,N).GT.0d0)) THEN
-          write(6,*) 'DFLX:',II,JJ,N,FLUX(II,JJ,N)
-         ENDIF
-        ENDDO
-        ENDDO 
-       ENDDO
-       CALL NcCl( fA1 )
-      ENDIF !LONLINEDUST
+      !Error Check
+      IF (ERR) THEN
+       RC = HCO_FAIL
+       RETURN
+      ENDIF
 
       !=================================================================
       ! PASS TO HEMCO STATE AND UPDATE DIAGNOSTICS 
@@ -1015,7 +915,6 @@
       ! Activate met fields used by this extension
       ExtState%SPHU%DoUse    = .TRUE.
       ExtState%TK%DoUse      = .TRUE.
-!      ExtState%TMPU1%DoUse   = .TRUE.
       ExtState%U10M%DoUse    = .TRUE.
       ExtState%V10M%DoUse    = .TRUE.
       ExtState%T2M%DoUse     = .TRUE.

--- a/HEMCO/Extensions/hcox_dustdead_mod.F
+++ b/HEMCO/Extensions/hcox_dustdead_mod.F
@@ -184,7 +184,7 @@
       INTEGER, PARAMETER   :: MVT              = 14
 
       ! New emission scheme settings
-      LOGICAL, PARAMETER     :: LKOKDIST = .TRUE.
+      LOGICAL, PARAMETER     :: LKOKDIST = .FALSE.
       CONTAINS
 !EOC
 !------------------------------------------------------------------------------
@@ -1747,6 +1747,8 @@
          ! fxm Temporarily set mss_frc_cly used in mobilization to globally
          !     uniform SGS value of 0.20, and put excess mass fraction
          !     into sand
+!         MSS_FRC_CLY_OUT(I) = Inst%MSS_FRC_CLY(I,J)
+!         MSS_FRC_SND_OUT(I) = Inst%MSS_FRC_SND(I,J)
          MSS_FRC_CLY_OUT(I) = MSS_FRC_CLY_GLB
          MSS_FRC_SND_OUT(I) = Inst%MSS_FRC_SND(I,J) +
      &                        Inst%MSS_FRC_CLY(I,J) - 
@@ -3712,9 +3714,9 @@
             !===========================================================
 
             ! [m3 m-3]
-!            GWC_THR(LON_IDX) = 0.17D0 + 0.14D0* MSS_FRC_CLY_SLC(LON_IDX)
-            GWC_THR(LON_IDX)=3.0d0*MSS_FRC_CLY_SLC(LON_IDX)*
-     &                       (0.17D0+0.14D0*MSS_FRC_CLY_SLC(LON_IDX))
+            GWC_THR(LON_IDX) = 0.17D0 + 0.14D0* MSS_FRC_CLY_SLC(LON_IDX)
+!            GWC_THR(LON_IDX)=3.0d0*MSS_FRC_CLY_SLC(LON_IDX)*
+!     &                       (0.17D0+0.14D0*MSS_FRC_CLY_SLC(LON_IDX))
             IF ( GWC_SFC(LON_IDX) > GWC_THR(LON_IDX) )
      &           FRC_THR_NCR_WTR(LON_IDX) = SQRT(1.0D0+1.21D0
      &           * (100.0D0 * (GWC_SFC(LON_IDX)-GWC_THR(LON_IDX)))

--- a/HEMCO/Extensions/hcox_lightnox_mod.F90
+++ b/HEMCO/Extensions/hcox_lightnox_mod.F90
@@ -1918,8 +1918,8 @@ CONTAINS
        WRITE( *,* ) '103     LightNOx         : on     NO'
        WRITE( *,* ) '    --> OTD-LIS scaling  :        1.00e-3'
          
-       CALL HCO_ERROR( HcoState%Config%Err, 'Wrong beta - see information in standard output', RC )
-       RETURN        
+!       CALL HCO_ERROR( HcoState%Config%Err, 'Wrong beta - see information in standard output', RC )
+!       RETURN        
  
     ENDIF
 

--- a/HEMCO/Interfaces/hcoi_standalone_mod.F90
+++ b/HEMCO/Interfaces/hcoi_standalone_mod.F90
@@ -624,7 +624,7 @@ CONTAINS
     LOGICAL             :: FOUND,   EOF
     CHARACTER(LEN=255)  :: MSG, LOC 
     CHARACTER(LEN=255)  :: MySpecFile 
-    CHARACTER(LEN=2047) :: DUM
+    CHARACTER(LEN=OPTLEN) :: DUM
 
     !=================================================================
     ! Model_GetSpecies begins here
@@ -856,7 +856,8 @@ CONTAINS
     CHARACTER(LEN=255)    :: LOC 
     CHARACTER(LEN=  1)    :: COL 
     CHARACTER(LEN=255)    :: MyGridFile 
-    CHARACTER(LEN=2047)   :: MSG, DUM
+    CHARACTER(LEN=2047)   :: MSG
+    CHARACTER(LEN=OPTLEN) :: DUM
 
     !=================================================================
     ! SET_GRID begins here
@@ -1711,7 +1712,8 @@ CONTAINS
     INTEGER             :: I,  N,   LNG, LOW
     LOGICAL             :: EOF, FOUND
     CHARACTER(LEN=  1)  :: COL
-    CHARACTER(LEN=255)  :: MSG, LOC, DUM
+    CHARACTER(LEN=255)  :: MSG, LOC
+    CHARACTER(LEN=OPTLEN) :: DUM
     CHARACTER(LEN=255)  :: MyTimeFile 
 
     !=================================================================

--- a/Headers/CMN_SIZE_mod.F
+++ b/Headers/CMN_SIZE_mod.F
@@ -396,6 +396,27 @@
 #endif
       REAL(fpp),  PARAMETER :: PTOP       = 0.01e+0_fpp
 
+#elif defined( GEOS_FP ) && defined( GRID025x03125 )
+
+      !-----------------------------------------------------------------
+      ! GEOS-FP Nested EU Grid
+      !-----------------------------------------------------------------
+      INTEGER               :: IGLOB      = 1152
+      INTEGER               :: JGLOB      = 721
+      INTEGER               :: LGLOB      = 72
+#if   defined( GRIDREDUCED )
+      INTEGER               :: LLPAR      = 47        ! Reduced vertical grid
+      INTEGER,    PARAMETER :: LLTROP_FIX = 38        !  -- 47 levels
+      INTEGER,    PARAMETER :: LLTROP     = 38
+      INTEGER,    PARAMETER :: LLSTRAT    = 44
+#else
+      INTEGER               :: LLPAR                  ! Full vertical grid
+      INTEGER,    PARAMETER :: LLTROP_FIX = 40        !  -- 72 levels
+      INTEGER,    PARAMETER :: LLTROP     = 40
+      INTEGER,    PARAMETER :: LLSTRAT    = 59
+#endif
+      REAL(fpp),  PARAMETER :: PTOP       = 0.01e+0_fpp
+
 #elif defined( GEOS_FP ) && defined( GRID2x25 )
 
       !-----------------------------------------------------------------

--- a/Headers/species_database_mod.F90
+++ b/Headers/species_database_mod.F90
@@ -1992,7 +1992,7 @@ CONTAINS
                               EmMW_g        = 12.0_fp,                      &
                               MolecRatio    = 1.0_fp,                       &
                               Is_Advected   = Is_Advected,                  &
-                              Is_Gas        = T,                            &
+                              Is_Gas        = F,                            &
                               Is_Drydep     = F,                            &
                               Is_Wetdep     = F,                            &
                               DD_DvzAerSnow = 0.03_fp,                      &
@@ -2020,7 +2020,7 @@ CONTAINS
                               EmMW_g        = 12.0_fp,                      &
                               MolecRatio    = 1.0_fp,                       &
                               Is_Advected   = Is_Advected,                  &
-                              Is_Gas        = T,                            &
+                              Is_Gas        = F,                            &
                               Is_Drydep     = F,                            &
                               Is_Wetdep     = F,                            &
                               DD_DvzAerSnow = 0.03_fp,                      &

--- a/Makefile_header.mk
+++ b/Makefile_header.mk
@@ -670,6 +670,7 @@ ifndef NO_GRID_NEEDED
     endif
 
     # Ensure that a nested-grid option is selected
+    # Comment out so that HEMCO Standalone can be run globally at nativee resolution
 #    ifndef NEST
 #      $(error $(ERR_NEST))
 #    else
@@ -689,12 +690,13 @@ ifndef NO_GRID_NEEDED
     endif
 
     # Ensure that a nested-grid option is selected
-    ifndef NEST
-      $(error $(ERR_NEST))
-    else
-      NEST_NEEDED    :=1
+    # Comment out so that HEMCO Standalone can be run globally at nativee resolution
+#    ifndef NEST
+#      $(error $(ERR_NEST))
+#    else
+#      NEST_NEEDED    :=1
       USER_DEFS      += -DGRID025x03125
-    endif
+#    endif
   endif
 
   # %%%%% ERROR CHECK!  Make sure our GRID selection is valid! %%%%%


### PR DESCRIPTION
Standard working version, Kok dust size distribution and emission parameterization changes switched off
(search LKOKDIST for the flag)
Additions to allow offline dust for GEOS-FP at native reoslution
Made dust FDG_FCT=1.0 for MERRA-2 05x0625 so that emissions are saved with no scaling. Scaling applied in HEMCO_Config now.
Switches to allow dust code to run with DEAD=FALSE in input
Switch to output diag files with start (rather than end) hour
Max output line length extended for reading in hi-res Grid edges
Hard coded switch LONLINEDUST for running dust code online versus just dumping offline data into the DST1-4 variables
Parallelization turned off for testing

